### PR TITLE
ENH: Provide long description for PyPI package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,8 @@ url = https://github.com/mgxd/ci-info
 author = Mathias Goncalves
 author_email = mathiasg@mit.edu
 description = Continuous Integration Information
+long_description = file:README.md
+long_description_content_type = text/markdown; charset=UTF-8; variant=GFM
 license = MIT
 provides =
     ci


### PR DESCRIPTION
Just plops the README in there, and marks it as Github-flavored markdown (GFM).