### PR TITLE
Fix license classification

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -11,7 +11,7 @@ provides =
 classifiers =
     Development Status :: 3 - Alpha
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License
+    License :: OSI Approved :: MIT
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9


### PR DESCRIPTION
This seems to be an oversight. The LICENSE file is clearly MIT.
