### PR TITLE
chore: update and add new CI providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ Officially supported CI servers:
 
 | Name                                                                            | isPR |
 | ------------------------------------------------------------------------------- | ---- |
-| [AWS CodeBuild](https://aws.amazon.com/codebuild/)                              | 🚫   |
+| [Agola CI](https://agola.io/)                                                   | ✅   |
+| [Appcircle](https://appcircle.io/)                                              | ✅   |
 | [AppVeyor](http://www.appveyor.com)                                             | ✅   |
+| [AWS CodeBuild](https://aws.amazon.com/codebuild/)                              | ✅   |
 | [Azure Pipelines](https://azure.microsoft.com/en-us/services/devops/pipelines/) | ✅   |
-| [Appcircle](https://appcircle.io/)                                              | 🚫   |
 | [Bamboo](https://www.atlassian.com/software/bamboo) by Atlassian                | 🚫   |
 | [Bitbucket Pipelines](https://bitbucket.org/product/features/pipelines)         | ✅   |
 | [Bitrise](https://www.bitrise.io/)                                              | ✅   |
@@ -27,32 +28,45 @@ Officially supported CI servers:
 | [Buildkite](https://buildkite.com)                                              | ✅   |
 | [CircleCI](http://circleci.com)                                                 | ✅   |
 | [Cirrus CI](https://cirrus-ci.org)                                              | ✅   |
+| [Cloudflare Pages](https://pages.cloudflare.com/)                               | 🚫   |
+| [Cloudflare Workers](https://pages.cloudflare.com/)                             | 🚫   |
 | [Codefresh](https://codefresh.io/)                                              | ✅   |
 | [Codeship](https://codeship.com)                                                | 🚫   |
 | [Drone](https://drone.io)                                                       | ✅   |
 | [dsari](https://github.com/rfinnie/dsari)                                       | 🚫   |
+| [Earthly CI](https://earthly.dev/)                                              | 🚫   |
 | [Expo Application Services](https://expo.dev/eas)                               | 🚫   |
+| [Gerrit CI](https://www.gerritcodereview.com)                                   | 🚫   |
 | [GitHub Actions](https://github.com/features/actions/)                          | ✅   |
 | [GitLab CI](https://about.gitlab.com/gitlab-ci/)                                | ✅   |
+| [Gitea Actions](https://about.gitea.com/)                                       | 🚫   |
 | [GoCD](https://www.go.cd/)                                                      | 🚫   |
+| [Google Cloud Build](https://cloud.google.com/build)                            | 🚫   |
+| [Harness CI](https://www.harness.io/products/continuous-integration)            | 🚫   |
+| [Heroku](https://www.heroku.com)                                                | 🚫   |
 | [Hudson](http://hudson-ci.org)                                                  | 🚫   |
 | [Jenkins CI](https://jenkins-ci.org)                                            | ✅   |
 | [LayerCI](https://layerci.com/)                                                 | ✅   |
 | [Magnum CI](https://magnum-ci.com)                                              | 🚫   |
 | [Netlify CI](https://www.netlify.com/)                                          | ✅   |
 | [Nevercode](http://nevercode.io/)                                               | ✅   |
+| [Prow](https://docs.prow.k8s.io/)                                               | 🚫   |
+| [ReleaseHub](https://releasehub.com/)                                           | 🚫   |
 | [Render](https://render.com/)                                                   | ✅   |
 | [Sail CI](https://sail.ci/)                                                     | ✅   |
 | [Screwdriver](https://screwdriver.cd/)                                          | ✅   |
 | [Semaphore](https://semaphoreci.com)                                            | ✅   |
 | [Shippable](https://www.shippable.com/)                                         | ✅   |
 | [Solano CI](https://www.solanolabs.com/)                                        | ✅   |
+| [Sourcehut](https://sourcehut.org/)                                             | 🚫   |
 | [Strider CD](https://strider-cd.github.io/)                                     | 🚫   |
 | [TaskCluster](http://docs.taskcluster.net)                                      | 🚫   |
 | [TeamCity](https://www.jetbrains.com/teamcity/) by JetBrains                    | 🚫   |
 | [Travis CI](http://travis-ci.org)                                               | ✅   |
-| [Vercel](https://vercel.com/)                                                   | 🚫   |
+| [Vela](https://go-vela.github.io/docs/)                                         | ✅   |
+| [Vercel](https://vercel.com/)                                                   | ✅   |
 | [Visual Studio App Center](https://appcenter.ms/)                               | 🚫   |
+| [Woodpecker](https://woodpecker-ci.org/)                                        | ✅   |
 
 
 ## Installation

--- a/ci_info/vendors.json
+++ b/ci_info/vendors.json
@@ -1,20 +1,45 @@
 [
   {
+    "name": "Agola CI",
+    "constant": "AGOLA",
+    "env": "AGOLA_GIT_REF",
+    "pr": "AGOLA_PULL_REQUEST_ID"
+  },
+  {
+    "name": "Appcircle",
+    "constant": "APPCIRCLE",
+    "env": "AC_APPCIRCLE",
+    "pr": {
+      "env": "AC_GIT_PR",
+      "ne": "false"
+    }
+  },
+  {
     "name": "AppVeyor",
     "constant": "APPVEYOR",
     "env": "APPVEYOR",
     "pr": "APPVEYOR_PULL_REQUEST_NUMBER"
   },
   {
-    "name": "Azure Pipelines",
-    "constant": "AZURE_PIPELINES",
-    "env": "SYSTEM_TEAMFOUNDATIONCOLLECTIONURI",
-    "pr": "SYSTEM_PULLREQUEST_PULLREQUESTID"
+    "name": "AWS CodeBuild",
+    "constant": "CODEBUILD",
+    "env": "CODEBUILD_BUILD_ARN",
+    "pr": {
+      "env": "CODEBUILD_WEBHOOK_EVENT",
+      "any": [
+        "PULL_REQUEST_CREATED",
+        "PULL_REQUEST_UPDATED",
+        "PULL_REQUEST_REOPENED"
+      ]
+    }
   },
   {
-    "name": "Appcircle",
-    "constant": "APPCIRCLE",
-    "env": "AC_APPCIRCLE"
+    "name": "Azure Pipelines",
+    "constant": "AZURE_PIPELINES",
+    "env": "TF_BUILD",
+    "pr": {
+      "BUILD_REASON": "PullRequest"
+    }
   },
   {
     "name": "Bamboo",
@@ -43,7 +68,10 @@
     "name": "Buildkite",
     "constant": "BUILDKITE",
     "env": "BUILDKITE",
-    "pr": { "env": "BUILDKITE_PULL_REQUEST", "ne": "false" }
+    "pr": {
+      "env": "BUILDKITE_PULL_REQUEST",
+      "ne": "false"
+    }
   },
   {
     "name": "CircleCI",
@@ -58,26 +86,46 @@
     "pr": "CIRRUS_PR"
   },
   {
-    "name": "AWS CodeBuild",
-    "constant": "CODEBUILD",
-    "env": "CODEBUILD_BUILD_ARN"
+    "name": "Cloudflare Pages",
+    "constant": "CLOUDFLARE_PAGES",
+    "env": "CF_PAGES"
+  },
+  {
+    "name": "Cloudflare Workers",
+    "constant": "CLOUDFLARE_WORKERS",
+    "env": "WORKERS_CI"
   },
   {
     "name": "Codefresh",
     "constant": "CODEFRESH",
     "env": "CF_BUILD_ID",
-    "pr": { "any": ["CF_PULL_REQUEST_NUMBER", "CF_PULL_REQUEST_ID"] }
+    "pr": {
+      "any": [
+        "CF_PULL_REQUEST_NUMBER",
+        "CF_PULL_REQUEST_ID"
+      ]
+    }
+  },
+  {
+    "name": "Codemagic",
+    "constant": "CODEMAGIC",
+    "env": "CM_BUILD_ID",
+    "pr": "CM_PULL_REQUEST"
   },
   {
     "name": "Codeship",
     "constant": "CODESHIP",
-    "env": { "CI_NAME": "codeship" }
+    "env": {
+      "CI_NAME": "codeship"
+    }
   },
   {
     "name": "Drone",
     "constant": "DRONE",
     "env": "DRONE",
-    "pr": { "DRONE_BUILD_EVENT": "pull_request" }
+    "pr": {
+      "DRONE_BUILD_EVENT": "pull_request"
+    }
   },
   {
     "name": "dsari",
@@ -85,15 +133,32 @@
     "env": "DSARI"
   },
   {
+    "name": "Earthly",
+    "constant": "EARTHLY",
+    "env": "EARTHLY_CI"
+  },
+  {
     "name": "Expo Application Services",
     "constant": "EAS",
     "env": "EAS_BUILD"
   },
   {
+    "name": "Gerrit",
+    "constant": "GERRIT",
+    "env": "GERRIT_PROJECT"
+  },
+  {
+    "name": "Gitea Actions",
+    "constant": "GITEA_ACTIONS",
+    "env": "GITEA_ACTIONS"
+  },
+  {
     "name": "GitHub Actions",
     "constant": "GITHUB_ACTIONS",
     "env": "GITHUB_ACTIONS",
-    "pr": { "GITHUB_EVENT_NAME": "pull_request" }
+    "pr": {
+      "GITHUB_EVENT_NAME": "pull_request"
+    }
   },
   {
     "name": "GitLab CI",
@@ -107,10 +172,22 @@
     "env": "GO_PIPELINE_LABEL"
   },
   {
-    "name": "LayerCI",
-    "constant": "LAYERCI",
-    "env": "LAYERCI",
-    "pr": "LAYERCI_PULL_REQUEST"
+    "name": "Google Cloud Build",
+    "constant": "GOOGLE_CLOUD_BUILD",
+    "env": "BUILDER_OUTPUT"
+  },
+  {
+    "name": "Harness CI",
+    "constant": "HARNESS",
+    "env": "HARNESS_BUILD_ID"
+  },
+  {
+    "name": "Heroku",
+    "constant": "HEROKU",
+    "env": {
+      "env": "NODE",
+      "includes": "/app/.heroku/node/bin/node"
+    }
   },
   {
     "name": "Hudson",
@@ -120,8 +197,22 @@
   {
     "name": "Jenkins",
     "constant": "JENKINS",
-    "env": ["JENKINS_URL", "BUILD_ID"],
-    "pr": { "any": ["ghprbPullId", "CHANGE_ID"] }
+    "env": [
+      "JENKINS_URL",
+      "BUILD_ID"
+    ],
+    "pr": {
+      "any": [
+        "ghprbPullId",
+        "CHANGE_ID"
+      ]
+    }
+  },
+  {
+    "name": "LayerCI",
+    "constant": "LAYERCI",
+    "env": "LAYERCI",
+    "pr": "LAYERCI_PULL_REQUEST"
   },
   {
     "name": "Magnum CI",
@@ -132,19 +223,37 @@
     "name": "Netlify CI",
     "constant": "NETLIFY",
     "env": "NETLIFY",
-    "pr": { "env": "PULL_REQUEST", "ne": "false" }
+    "pr": {
+      "env": "PULL_REQUEST",
+      "ne": "false"
+    }
   },
   {
     "name": "Nevercode",
     "constant": "NEVERCODE",
     "env": "NEVERCODE",
-    "pr": { "env": "NEVERCODE_PULL_REQUEST", "ne": "false" }
+    "pr": {
+      "env": "NEVERCODE_PULL_REQUEST",
+      "ne": "false"
+    }
+  },
+  {
+    "name": "Prow",
+    "constant": "PROW",
+    "env": "PROW_JOB_ID"
+  },
+  {
+    "name": "ReleaseHub",
+    "constant": "RELEASEHUB",
+    "env": "RELEASE_BUILD_ID"
   },
   {
     "name": "Render",
     "constant": "RENDER",
     "env": "RENDER",
-    "pr": { "IS_PULL_REQUEST": "true" }
+    "pr": {
+      "IS_PULL_REQUEST": "true"
+    }
   },
   {
     "name": "Sail CI",
@@ -153,28 +262,26 @@
     "pr": "SAIL_PULL_REQUEST_NUMBER"
   },
   {
+    "name": "Screwdriver",
+    "constant": "SCREWDRIVER",
+    "env": "SCREWDRIVER",
+    "pr": {
+      "env": "SD_PULL_REQUEST",
+      "ne": "false"
+    }
+  },
+  {
     "name": "Semaphore",
     "constant": "SEMAPHORE",
     "env": "SEMAPHORE",
     "pr": "PULL_REQUEST_NUMBER"
   },
   {
-    "name": "Screwdriver",
-    "constant": "SCREWDRIVER",
-    "env": "SCREWDRIVER",
-    "pr": { "env": "SD_PULL_REQUEST", "ne": "false" }
-  },
-  {
-    "name": "Shippable",
-    "constant": "SHIPPABLE",
-    "env": "SHIPPABLE",
-    "pr": { "IS_PULL_REQUEST": "true" }
-  },
-  {
-    "name": "Solano CI",
-    "constant": "SOLANO",
-    "env": "TDDIUM",
-    "pr": "TDDIUM_PR_ID"
+    "name": "Sourcehut",
+    "constant": "SOURCEHUT",
+    "env": {
+      "CI_NAME": "sourcehut"
+    }
   },
   {
     "name": "Strider CD",
@@ -184,7 +291,10 @@
   {
     "name": "TaskCluster",
     "constant": "TASKCLUSTER",
-    "env": ["TASK_ID", "RUN_ID"]
+    "env": [
+      "TASK_ID",
+      "RUN_ID"
+    ]
   },
   {
     "name": "TeamCity",
@@ -195,16 +305,54 @@
     "name": "Travis CI",
     "constant": "TRAVIS",
     "env": "TRAVIS",
-    "pr": { "env": "TRAVIS_PULL_REQUEST", "ne": "false" }
+    "pr": {
+      "env": "TRAVIS_PULL_REQUEST",
+      "ne": "false"
+    }
+  },
+  {
+    "name": "Vela",
+    "constant": "VELA",
+    "env": "VELA",
+    "pr": {
+      "VELA_PULL_REQUEST": "1"
+    }
   },
   {
     "name": "Vercel",
     "constant": "VERCEL",
-    "env": "NOW_BUILDER"
+    "env": {
+      "any": [
+        "NOW_BUILDER",
+        "VERCEL"
+      ]
+    },
+    "pr": "VERCEL_GIT_PULL_REQUEST_ID"
   },
   {
     "name": "Visual Studio App Center",
     "constant": "APPCENTER",
     "env": "APPCENTER_BUILD_ID"
+  },
+  {
+    "name": "Woodpecker",
+    "constant": "WOODPECKER",
+    "env": {
+      "CI": "woodpecker"
+    },
+    "pr": {
+      "CI_BUILD_EVENT": "pull_request"
+    }
+  },
+  {
+    "name": "Xcode Cloud",
+    "constant": "XCODE_CLOUD",
+    "env": "CI_XCODE_PROJECT",
+    "pr": "CI_PULL_REQUEST_NUMBER"
+  },
+  {
+    "name": "Xcode Server",
+    "constant": "XCODE_SERVER",
+    "env": "XCS"
   }
 ]


### PR DESCRIPTION
- Enable isPR detection for AWS CodeBuild, Appcircle, and Vercel
- Add new CI providers: Agola CI, Cloudflare Pages, Cloudflare Workers, Earthly CI, Gerrit CI, Gitea Actions, Google Cloud Build, Harness CI, Heroku, Prow, ReleaseHub, Sourcehut, Vela, and Woodpecker